### PR TITLE
use clang integrated as

### DIFF
--- a/cc/config/riscv64_device.go
+++ b/cc/config/riscv64_device.go
@@ -112,7 +112,7 @@ func (t *toolchainRiscv64) ToolchainClangCflags() string {
 }
 
 func (t *toolchainRiscv64) ClangAsflags() string {
-	return "-fno-integrated-as"
+	return ""
 }
 
 func (t *toolchainRiscv64) ClangCflags() string {


### PR DESCRIPTION
Refer to https://github.com/riscv-android-src/toolchain-llvm-project/issues/3#issuecomment-1047399421

Use current new aosp and clang, I find replace as and it works.

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>