### PR TITLE
add no-relax

### DIFF
--- a/cc/config/riscv64_device.go
+++ b/cc/config/riscv64_device.go
@@ -27,6 +27,7 @@ var (
 		"-Wno-implicit-int-float-conversion",
 		"-Wno-deprecated-copy",
 		"-Wno-implicit-fallthrough",
+		"-mno-relax",
 	}
 
 	riscv64ClangCflags = append(riscv64Cflags, []string{


### PR DESCRIPTION
Upstreaming LLD doesn't support linker relaxation for RISCV. When the
linker find relocations that used by linker relaxation, it will report
error and suggest us to compile with -mno-relax

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>