### PR TITLE
remove build options for aosp 10

### DIFF
--- a/cc/config/global.go
+++ b/cc/config/global.go
@@ -55,19 +55,6 @@ var (
 		"-Werror=pragma-pack-suspicious-include",
 		"-Werror=string-plus-int",
 		"-Werror=unreachable-code-loop-increment",
-		"-Wno-implicit-int-float-conversion",
-		"-Wno-deprecated-copy",
-		"-Wno-implicit-fallthrough",
-		"-Wno-unused-parameter",
-		"-Wno-deprecated-copy",
-		"-Wno-int-in-bool-context",
-		"-Wno-tautological-overlap-compare",
-		"-Wno-c99-designator",
-		"-Wno-reorder-init-list",
-		"-Wno-int-in-bool-context",
-		"-Wno-bool-operation",
-		"-Wno-return-type",
-		"-Wno-sometimes-uninitialized",
 	}
 
 	commonGlobalConlyflags = []string{}


### PR DESCRIPTION
Some build options are added for aosp 10, now they are
not needed.

This PR has dependency on anther PR https://github.com/riscv-android-src/platform-frameworks-av/pull/1.

Signed-off-by: Wang Chen <wangchen20@iscas.ac.cn>